### PR TITLE
feat: skip verification digit validation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Valida que un string sea un RFC válido y entrega detalles sobre la validación.
 | Parámetro | Tipo | Descripción |
 | --------- | ---- | ----------- |
 |`rfc`|String|El RFC a validar.|
+|`options`|Object| Opciones de la función (Opcional).|
+|`options.omitVerificationDigit`|Boolean| Si esta opción es `true`, el dígito verificatdor no será validado. (Default: `false`).|
 
 
 **Respuesta**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validate-rfc",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "A simple library to validate mexican RFCs",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validate-rfc",
-  "version": "2.0.0",
+  "version": "1.0.4",
   "description": "A simple library to validate mexican RFCs",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export default function validateRfc(rfc: string, options?: { strict?: boolean }): {
+export default function validateRfc(rfc: string, options?: { omitVerificationDigit?: boolean }): {
   isValid: boolean,
   type?: 'company' | 'person' | 'foreign' | 'generic',
   rfc?: string,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export default function validateRfc(rfc: string): {
+export default function validateRfc(rfc: string, strict?: boolean): {
   isValid: boolean,
   type?: 'company' | 'person' | 'foreign' | 'generic',
   rfc?: string,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export default function validateRfc(rfc: string, strict?: boolean): {
+export default function validateRfc(rfc: string, options?: { strict?: boolean }): {
   isValid: boolean,
   type?: 'company' | 'person' | 'foreign' | 'generic',
   rfc?: string,

--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,10 @@ const validateVerificationDigit = (rfc) => {
   return expected === digit;
 };
 
-const validate = (rfc, strict) => {
+const validate = (rfc, options = {}) => {
   if (isSpecialCase(rfc)) return [];
   const errors = [];
+  const strict = options.strict !== false;
   const hasValidFormat = RFC_REGEXP.test(rfc);
   const hasValidDate = hasValidFormat ? validateDate(rfc) : true;
   const hasValidDigit = hasValidFormat ? validateVerificationDigit(rfc) : true;

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const validateVerificationDigit = (rfc) => {
   return expected === digit;
 };
 
-const validate = (rfc) => {
+const validate = (rfc, strict) => {
   if (isSpecialCase(rfc)) return [];
   const errors = [];
   const hasValidFormat = RFC_REGEXP.test(rfc);
@@ -43,7 +43,7 @@ const validate = (rfc) => {
   const hasValidDigit = hasValidFormat ? validateVerificationDigit(rfc) : true;
   if (!hasValidFormat) errors.push(INVALID_FORMAT_ERROR);
   if (!hasValidDate) errors.push(INVALID_DATE_ERROR);
-  if (!hasValidDigit) errors.push(INVALID_VERIFICATION_DIGIT_ERROR);
+  if (!hasValidDigit && strict) errors.push(INVALID_VERIFICATION_DIGIT_ERROR);
   return errors;
 };
 
@@ -64,9 +64,9 @@ const getInvalidResponse = (errors) => ({
   errors
 });
 
-module.exports = (input) => {
+module.exports = (input, strict = false) => {
   const rfc = parseInput(input);
-  const errors = validate(rfc);
+  const errors = validate(rfc, strict);
   const isValid = errors.length === 0;
 
   return isValid ? getValidResponse(rfc) : getInvalidResponse(errors);

--- a/src/index.js
+++ b/src/index.js
@@ -38,13 +38,13 @@ const validateVerificationDigit = (rfc) => {
 const validate = (rfc, options = {}) => {
   if (isSpecialCase(rfc)) return [];
   const errors = [];
-  const strict = options.strict !== false;
+  const skipDigit = options.omitVerificationDigit;
   const hasValidFormat = RFC_REGEXP.test(rfc);
   const hasValidDate = hasValidFormat ? validateDate(rfc) : true;
   const hasValidDigit = hasValidFormat ? validateVerificationDigit(rfc) : true;
   if (!hasValidFormat) errors.push(INVALID_FORMAT_ERROR);
   if (!hasValidDate) errors.push(INVALID_DATE_ERROR);
-  if (!hasValidDigit && strict) errors.push(INVALID_VERIFICATION_DIGIT_ERROR);
+  if (!hasValidDigit && !skipDigit) errors.push(INVALID_VERIFICATION_DIGIT_ERROR);
   return errors;
 };
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -99,9 +99,9 @@ describe('.validateRfc', () => {
       });
     });
 
-    it('should return not valid and specify errors when verification digit is not correct in strict mode', () => {
+    it('should return not valid and specify errors when verification digit is not correct', () => {
       const rfc = 'MHTR810511A79';
-      const response = validateRfc(rfc, true);
+      const response = validateRfc(rfc);
       expect(response).to.be.eql({
         rfc: null,
         isValid: false,
@@ -110,9 +110,9 @@ describe('.validateRfc', () => {
       });
     });
 
-    it('should skip verification digit validation by default', () => {
+    it('should skip verification digit validation when strict mode is off', () => {
       const rfc = 'MHTR810511A79';
-      const response = validateRfc(rfc);
+      const response = validateRfc(rfc, { strict: false });
       expect(response).to.be.eql({
         rfc,
         isValid: true,
@@ -122,7 +122,7 @@ describe('.validateRfc', () => {
 
     it('should return multiple errors when is required', () => {
       const rfc = 'MHTR815511778';
-      const response = validateRfc(rfc, true);
+      const response = validateRfc(rfc);
       expect(response).to.be.eql({
         rfc: null,
         isValid: false,

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -110,9 +110,9 @@ describe('.validateRfc', () => {
       });
     });
 
-    it('should skip verification digit validation when strict mode is off', () => {
+    it('should skip verification digit validation when `omitVerificationDigit` is true', () => {
       const rfc = 'MHTR810511A79';
-      const response = validateRfc(rfc, { strict: false });
+      const response = validateRfc(rfc, { omitVerificationDigit: true });
       expect(response).to.be.eql({
         rfc,
         isValid: true,

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -66,7 +66,7 @@ describe('.validateRfc', () => {
   });
 
   describe('when RFC is not valid', () => {
-    it('should retrun not valid and specify errors when input is not a string', () => {
+    it('should return not valid and specify errors when input is not a string', () => {
       const rfc = null;
       const response = validateRfc(rfc);
       expect(response).to.be.eql({
@@ -77,7 +77,7 @@ describe('.validateRfc', () => {
       });
     });
 
-    it('should retrun not valid and specify errors when format is incorrect', () => {
+    it('should return not valid and specify errors when format is incorrect', () => {
       const rfc = 'INVALID_RFC';
       const response = validateRfc(rfc);
       expect(response).to.be.eql({
@@ -88,7 +88,7 @@ describe('.validateRfc', () => {
       });
     });
 
-    it('should retrun not valid and specify errors when format is correct but date is not', () => {
+    it('should return not valid and specify errors when format is correct but date is not', () => {
       const rfc = 'MHTR815511A70';
       const response = validateRfc(rfc);
       expect(response).to.be.eql({
@@ -99,9 +99,9 @@ describe('.validateRfc', () => {
       });
     });
 
-    it('should retrun not valid and specify errors when verification digit is not correct', () => {
+    it('should return not valid and specify errors when verification digit is not correct in strict mode', () => {
       const rfc = 'MHTR810511A79';
-      const response = validateRfc(rfc);
+      const response = validateRfc(rfc, true);
       expect(response).to.be.eql({
         rfc: null,
         isValid: false,
@@ -110,9 +110,19 @@ describe('.validateRfc', () => {
       });
     });
 
-    it('should retrun multiple errors when is required', () => {
-      const rfc = 'MHTR815511778';
+    it('should skip verification digit validation by default', () => {
+      const rfc = 'MHTR810511A79';
       const response = validateRfc(rfc);
+      expect(response).to.be.eql({
+        rfc,
+        isValid: true,
+        type: 'person'
+      });
+    });
+
+    it('should return multiple errors when is required', () => {
+      const rfc = 'MHTR815511778';
+      const response = validateRfc(rfc, true);
       expect(response).to.be.eql({
         rfc: null,
         isValid: false,


### PR DESCRIPTION
Due to inconsistency in the SAT's specification about the RFC's verification digit, this PR implements a behavior to ignore by default the last digit through the optional parameter `strict` in `validate()`

Closes #10 